### PR TITLE
Deadspace

### DIFF
--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -215,7 +215,7 @@ obj/item/projectile/kinetic/New()
 			name = "full strength plasma blast"
 			damage *= 3
 			sharpness = IS_SHARP
-		    sharpness = IS_SHARP_ACCURATE
+
 
 	..()
 

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -215,7 +215,7 @@ obj/item/projectile/kinetic/New()
 			name = "full strength plasma blast"
 			damage *= 3
 			sharpness = IS_SHARP
-
+		    sharpness = IS_SHARP_ACCURATE
 
 	..()
 

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -214,6 +214,9 @@ obj/item/projectile/kinetic/New()
 		if(pressure < 30)
 			name = "full strength plasma blast"
 			damage *= 3
+			sharpness = IS_SHARP
+
+
 	..()
 
 /obj/item/projectile/plasma/on_hit(atom/target)


### PR DESCRIPTION
Allows plasma cutters to dismemeber limbs by targetting the chosen limb and firing at it.
